### PR TITLE
Add BMR and clarify skeletal muscle mass exports

### DIFF
--- a/src/Api/Contracts/BodyCompositionRequest.cs
+++ b/src/Api/Contracts/BodyCompositionRequest.cs
@@ -9,6 +9,9 @@ namespace Api.Contracts
         public float? PercentFat { set; get; }
         public float? PercentHydration { set; get; }
         public float? BoneMass { set; get; }
+        public float? SkeletalMuscleMass { set; get; }
+
+        // Retained so older proxy clients continue to upload this value.
         public float? MuscleMass { set; get; }
         public float? VisceralFatRating { set; get; }
         public float? VisceralFatMass { set; get; }

--- a/src/Api/Contracts/BodyCompositionRequest.cs
+++ b/src/Api/Contracts/BodyCompositionRequest.cs
@@ -15,6 +15,7 @@ namespace Api.Contracts
         public float? PhysiqueRating { set; get; }
         public float? MetabolicAge { set; get; }
         public float? bodyMassIndex { get; set; }
+        public float? BasalMet { get; set; }
         public bool CreateOnlyFile { get; set; } = false;
         public string Email { set; get; } = default!;
         public string Password { set; get; } = default!;

--- a/src/Api/Endpoints/UploadEndpoints.cs
+++ b/src/Api/Endpoints/UploadEndpoints.cs
@@ -62,6 +62,7 @@ public static class UploadEndpoints
                     PhysiqueRating = request.PhysiqueRating.HasValue ? (byte)Math.Round(request.PhysiqueRating.Value) : null,
                     MetabolicAge = request.MetabolicAge.HasValue ? (byte)Math.Round(request.MetabolicAge.Value) : null,
                     BodyMassIndex = request.bodyMassIndex,
+                    BasalMet = request.BasalMet,
                 };
 
                 logger.LogDebug("Prepared GarminWeightScaleDTO: {@GarminWeightScaleDTO}", garminWeightScaleDTO);

--- a/src/Api/Endpoints/UploadEndpoints.cs
+++ b/src/Api/Endpoints/UploadEndpoints.cs
@@ -56,7 +56,7 @@ public static class UploadEndpoints
                     PercentFat = request.PercentFat,
                     PercentHydration = request.PercentHydration,
                     BoneMass = request.BoneMass,
-                    MuscleMass = request.MuscleMass,
+                    SkeletalMuscleMass = request.SkeletalMuscleMass ?? request.MuscleMass,
                     VisceralFatRating = request.VisceralFatRating.HasValue ? (byte)Math.Round(request.VisceralFatRating.Value) : null,
                     VisceralFatMass = request.VisceralFatMass,
                     PhysiqueRating = request.PhysiqueRating.HasValue ? (byte)Math.Round(request.PhysiqueRating.Value) : null,

--- a/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommand.cs
+++ b/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommand.cs
@@ -42,7 +42,7 @@ namespace YAGCC.Commands.UploadBodyComposition
                     PercentFat = request.PercentFat,
                     PercentHydration = request.PercentHydration,
                     BoneMass = request.BoneMass,
-                    MuscleMass = request.MuscleMass,
+                    SkeletalMuscleMass = request.SkeletalMuscleMass,
                     VisceralFatRating = request.VisceralFatRating.HasValue ? (byte)Math.Round(request.VisceralFatRating.Value) : null,
                     VisceralFatMass = request.VisceralFatMass,
                     PhysiqueRating = request.PhysiqueRating.HasValue ? (byte)Math.Round(request.PhysiqueRating.Value) : null,

--- a/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommandSettings.cs
+++ b/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommandSettings.cs
@@ -26,9 +26,9 @@ namespace YAGCC.Commands.UploadBodyComposition
         [Description("Set your bone mass in kilograms")]
         public float? BoneMass { set; get; }
 
-        [CommandOption("-m|--muscle-mass")]
-        [Description("Set your muscle mass in kilograms")]
-        public float? MuscleMass { set; get; }
+        [CommandOption("-m|--skeletal-muscle-mass|--muscle-mass")]
+        [Description("Set your skeletal muscle mass in kilograms")]
+        public float? SkeletalMuscleMass { set; get; }
 
         [CommandOption("--visceral-fat")]
         [Description("Set your visceral fat rating")]

--- a/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
+++ b/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
@@ -29,7 +29,20 @@ namespace YetAnotherGarminConnectClient.Dto.Garmin.Fit
         public float? PercentFat { set; get; }
         public float? PercentHydration { set; get; }
         public float? BoneMass { set; get; }
-        public float? MuscleMass { set; get; }
+        /// <summary>
+        /// Skeletal muscle mass in kilograms. Garmin's FIT profile names this field muscle_mass.
+        /// </summary>
+        public float? SkeletalMuscleMass { set; get; }
+
+        /// <summary>
+        /// Backwards-compatible alias for <see cref="SkeletalMuscleMass"/>.
+        /// </summary>
+        [Obsolete("Use SkeletalMuscleMass. Garmin's muscle_mass FIT field represents skeletal muscle mass.")]
+        public float? MuscleMass
+        {
+            get => SkeletalMuscleMass;
+            set => SkeletalMuscleMass = value;
+        }
         public byte? VisceralFatRating { set; get; }
         public float? VisceralFatMass { set; get; }
         public byte? PhysiqueRating { set; get; }

--- a/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
+++ b/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
@@ -35,6 +35,7 @@ namespace YetAnotherGarminConnectClient.Dto.Garmin.Fit
         public byte? PhysiqueRating { set; get; }
         public byte? MetabolicAge { set; get; }
         public float? BodyMassIndex { set; get; }
+        public float? BasalMet { set; get; }
     }
 
     public record GarminWeightScaleDTO : GarminWeightScaleData

--- a/src/YetAnotherGarminConnectClient/FitFileCreator.cs
+++ b/src/YetAnotherGarminConnectClient/FitFileCreator.cs
@@ -54,6 +54,8 @@ namespace YetAnotherGarminConnectClient
                     weightMesg.SetPercentHydration(garminWeightScaleData.PercentHydration);
                 if (garminWeightScaleData.MuscleMass is not null)
                     weightMesg.SetMuscleMass(garminWeightScaleData.MuscleMass);
+                if (garminWeightScaleData.BasalMet is not null)
+                    weightMesg.SetBasalMet(garminWeightScaleData.BasalMet);
                 if (garminWeightScaleData.BoneMass is not null)
                     weightMesg.SetBoneMass(garminWeightScaleData.BoneMass);
                 if (garminWeightScaleData.MetabolicAge is not null)

--- a/src/YetAnotherGarminConnectClient/FitFileCreator.cs
+++ b/src/YetAnotherGarminConnectClient/FitFileCreator.cs
@@ -52,8 +52,8 @@ namespace YetAnotherGarminConnectClient
                     weightMesg.SetPercentFat(garminWeightScaleData.PercentFat);
                 if (garminWeightScaleData.PercentHydration is not null)
                     weightMesg.SetPercentHydration(garminWeightScaleData.PercentHydration);
-                if (garminWeightScaleData.MuscleMass is not null)
-                    weightMesg.SetMuscleMass(garminWeightScaleData.MuscleMass);
+                if (garminWeightScaleData.SkeletalMuscleMass is not null)
+                    weightMesg.SetMuscleMass(garminWeightScaleData.SkeletalMuscleMass);
                 if (garminWeightScaleData.BasalMet is not null)
                     weightMesg.SetBasalMet(garminWeightScaleData.BasalMet);
                 if (garminWeightScaleData.BoneMass is not null)

--- a/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
+++ b/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
@@ -41,6 +41,7 @@ namespace Api.Tests.Helpers
                 PhysiqueRating = 3,
                 MetabolicAge = 35,
                 bodyMassIndex = 24.5f,
+                BasalMet = 1650f,
                 TimeStamp = null,
                 CreateOnlyFile = false
             };

--- a/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
+++ b/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
@@ -35,7 +35,7 @@ namespace Api.Tests.Helpers
                 PercentFat = 20.5f,
                 PercentHydration = 55.0f,
                 BoneMass = 3.2f,
-                MuscleMass = 30.0f,
+                SkeletalMuscleMass = 30.0f,
                 VisceralFatRating = 5,
                 VisceralFatMass = 2.5f,
                 PhysiqueRating = 3,

--- a/tests/ClientTests.cs
+++ b/tests/ClientTests.cs
@@ -34,7 +34,7 @@ namespace YetAnotherGarminConnectClient.Tests
                 PercentFat = 10.1f,
                 PercentHydration = 53.3f,
                 BoneMass = 5.8f,
-                MuscleMass = 32f,
+                SkeletalMuscleMass = 32f,
                 VisceralFatRating = 9,
                 VisceralFatMass = 10f,
                 PhysiqueRating = 9,

--- a/tests/FitFileCreatorTests.cs
+++ b/tests/FitFileCreatorTests.cs
@@ -8,13 +8,13 @@ namespace YetAnotherGarminConnectClient.Tests;
 public class FitFileCreatorTests
 {
     [Test]
-    public void WeightFitFileRoundTripsBasalMetAndMuscleMass()
+    public void WeightFitFileRoundTripsBasalMetAndSkeletalMuscleMass()
     {
         var data = new GarminWeightScaleData
         {
             TimeStamp = new System.DateTime(2026, 7, 12, 8, 30, 0, DateTimeKind.Utc),
             Weight = 74.2f,
-            MuscleMass = 40.0f,
+            SkeletalMuscleMass = 40.0f,
             BasalMet = 1650f,
         };
         var profile = new UserProfileSettings { Age = 29, Height = 182 };
@@ -57,5 +57,15 @@ public class FitFileCreatorTests
         Assert.That(decode.Read(stream), Is.True);
         Assert.That(decoded, Is.Not.Null);
         Assert.That(decoded!.GetBasalMet(), Is.Null);
+    }
+
+    [Test]
+    public void LegacyMuscleMassAliasPopulatesSkeletalMuscleMass()
+    {
+#pragma warning disable CS0618
+        var data = new GarminWeightScaleData { MuscleMass = 39.5f };
+#pragma warning restore CS0618
+
+        Assert.That(data.SkeletalMuscleMass, Is.EqualTo(39.5f));
     }
 }

--- a/tests/FitFileCreatorTests.cs
+++ b/tests/FitFileCreatorTests.cs
@@ -1,0 +1,61 @@
+using Dynastream.Fit;
+using NUnit.Framework;
+using YetAnotherGarminConnectClient.Dto.Garmin.Fit;
+
+namespace YetAnotherGarminConnectClient.Tests;
+
+[TestFixture]
+public class FitFileCreatorTests
+{
+    [Test]
+    public void WeightFitFileRoundTripsBasalMetAndMuscleMass()
+    {
+        var data = new GarminWeightScaleData
+        {
+            TimeStamp = new System.DateTime(2026, 7, 12, 8, 30, 0, DateTimeKind.Utc),
+            Weight = 74.2f,
+            MuscleMass = 40.0f,
+            BasalMet = 1650f,
+        };
+        var profile = new UserProfileSettings { Age = 29, Height = 182 };
+
+        var bytes = FitFileCreator.CreateWeightBodyCompositionFitFile(data, profile);
+        var decode = new Decode();
+        var broadcaster = new MesgBroadcaster();
+        WeightScaleMesg? decoded = null;
+
+        decode.MesgEvent += broadcaster.OnMesg;
+        broadcaster.WeightScaleMesgEvent += (_, args) => decoded = new WeightScaleMesg(args.mesg);
+
+        using var stream = new MemoryStream(bytes);
+        Assert.That(decode.Read(stream), Is.True);
+        Assert.That(decoded, Is.Not.Null);
+        Assert.That(decoded!.GetBasalMet(), Is.EqualTo(1650f).Within(0.25f));
+        Assert.That(decoded.GetMuscleMass(), Is.EqualTo(40.0f).Within(0.01f));
+    }
+
+    [Test]
+    public void WeightFitFileOmitsBasalMetWhenItIsNull()
+    {
+        var data = new GarminWeightScaleData
+        {
+            TimeStamp = new System.DateTime(2026, 7, 12, 8, 30, 0, DateTimeKind.Utc),
+            Weight = 74.2f,
+            BasalMet = null,
+        };
+        var profile = new UserProfileSettings { Age = 29, Height = 182 };
+
+        var bytes = FitFileCreator.CreateWeightBodyCompositionFitFile(data, profile);
+        var decode = new Decode();
+        var broadcaster = new MesgBroadcaster();
+        WeightScaleMesg? decoded = null;
+
+        decode.MesgEvent += broadcaster.OnMesg;
+        broadcaster.WeightScaleMesgEvent += (_, args) => decoded = new WeightScaleMesg(args.mesg);
+
+        using var stream = new MemoryStream(bytes);
+        Assert.That(decode.Read(stream), Is.True);
+        Assert.That(decoded, Is.Not.Null);
+        Assert.That(decoded!.GetBasalMet(), Is.Null);
+    }
+}

--- a/tests/GarminConnectClientTests.cs
+++ b/tests/GarminConnectClientTests.cs
@@ -40,7 +40,7 @@ namespace YetAnotherGarminConnectClient.Tests
                 PercentFat = 10.1f,
                 PercentHydration = 53.3f,
                 BoneMass = 5.8f,
-                MuscleMass = 32f,
+                SkeletalMuscleMass = 32f,
                 VisceralFatRating = 9,
                 VisceralFatMass = 10f,
                 PhysiqueRating = 9,


### PR DESCRIPTION
## Summary

- expose nullable BasalMet on Garmin weight DTOs and encode it through WeightScaleMesg.SetBasalMet
- expose SkeletalMuscleMass as the canonical public name while retaining MuscleMass as an obsolete source-compatible alias
- keep Garmin FIT serialization on the protocol-defined muscle_mass field
- accept SkeletalMuscleMass and the legacy MuscleMass property in the proxy API
- add --skeletal-muscle-mass to the CLI while retaining --muscle-mass as an alias
- add FIT round-trip and compatibility coverage

## Companion application change

- https://github.com/lswiderski/mi-scale-exporter/pull/79 completes the S400 mapping and fixes mi-scale-exporter#55

## Verification

- library, API, CLI, and test projects compile successfully
- generated FIT decoded with basal_met=1702 and muscle_mass=40
- app mapper tests pass 8/8 against the updated project
- combined YAGCC test execution remains unavailable because this machine lacks the x64 ASP.NET 8 runtime